### PR TITLE
session attribute serialization; cast exception if sessionTimeout is not set

### DIFF
--- a/RedisDatabaseSessionGrailsPlugin.groovy
+++ b/RedisDatabaseSessionGrailsPlugin.groovy
@@ -1,12 +1,9 @@
-import grails.plugin.redissession.RedisPersistentService
-import grails.plugin.redissession.RedisSessionCleanupService
-import grails.plugin.databasesession.SessionProxyFilter
 import org.codehaus.groovy.grails.web.servlet.mvc.SynchronizerTokensHolder
 
 import javax.servlet.http.HttpSession
 
 class RedisDatabaseSessionGrailsPlugin {
-    def version = "1.2.2"
+    def version = "1.2.3"
     def grailsVersion = "2.0 > *"
     def loadAfter = ["database-session", "redis"]
     def dependsOn = ["database-session":"1.2.1 > *", "redis":"1.5.2 > *"]

--- a/grails-app/services/grails/plugin/redissession/RedisPersistentService.groovy
+++ b/grails-app/services/grails/plugin/redissession/RedisPersistentService.groovy
@@ -13,7 +13,7 @@ import redis.clients.jedis.Jedis
  * @author Roberto Perez
  * @author Raj Govindarajan
  */
-class RedisPersistentService implements Persister  {
+class RedisPersistentService implements Persister {
     static transactional = false
     def redisService
     def grailsApplication
@@ -58,9 +58,7 @@ class RedisPersistentService implements Persister  {
         if (GrailsApplicationAttributes.FLASH_SCOPE == key && !storeFlashScopeWithRedis()) {
             // special case; use request scope since a new deserialized instance is created each time it's retrieved from the session
             def fs = SessionProxyFilter.request.getAttribute(GrailsApplicationAttributes.FLASH_SCOPE)
-            if (fs != null) {
-                return fs
-            }
+            return fs
         }
 
         def attribute = null
@@ -186,7 +184,7 @@ class RedisPersistentService implements Persister  {
     }
 
     long getLastAccessedTime(String sessionId) throws InvalidatedSessionException {
-        Long lastAccessedTime  = null
+        Long lastAccessedTime = null
         redisService.withRedis { Jedis redis ->
             def sessionProperties = redis.hgetAll("${SESSION_PREFIX}${sessionId}")
             lastAccessedTime = redis.zscore(LAST_ACCESSED_TIME_ZSET, sessionId)?.toLong()

--- a/grails-app/services/grails/plugin/redissession/RedisPersistentService.groovy
+++ b/grails-app/services/grails/plugin/redissession/RedisPersistentService.groovy
@@ -76,7 +76,7 @@ class RedisPersistentService implements Persister  {
                 //Updating the session last accessed time in the zset
                 redis.zadd(LAST_ACCESSED_TIME_ZSET, System.currentTimeMillis(), sessionId)
 
-                def serializedAttribute = redis.hget((serialize("${SESSION_ATTRIBUTES_PREFIX}${sessionId}")), serialize(key))
+                def serializedAttribute = redis.hget(serialize("${SESSION_ATTRIBUTES_PREFIX}${sessionId}"), serialize(key))
                 attribute = deserialize(serializedAttribute)
             }
 
@@ -135,7 +135,9 @@ class RedisPersistentService implements Persister  {
         try {
             redisService.withRedis { Jedis redis ->
                 if (redis.exists(serialize("${SESSION_ATTRIBUTES_PREFIX}${sessionId}"))) {
-                    redis.hdel(serialize("${SESSION_ATTRIBUTES_PREFIX}${sessionId}"), serialize(key))
+                    // redis.hdel(byte[] key, byte[]... fields) cannot be called with just one field!
+                    byte[] serialzedKey = serialize(key)
+                    redis.hdel(serialize("${SESSION_ATTRIBUTES_PREFIX}${sessionId}"), serialzedKey, serialzedKey)
                 }
             }
         }
@@ -151,7 +153,7 @@ class RedisPersistentService implements Persister  {
         try {
             redisService.withRedis { Jedis redis ->
                 if (redis.exists(serialize("${SESSION_ATTRIBUTES_PREFIX}${sessionId}"))) {
-                    result = redis.hkeys((serialize("${SESSION_ATTRIBUTES_PREFIX}${sessionId}")))
+                    result = redis.hkeys(serialize("${SESSION_ATTRIBUTES_PREFIX}${sessionId}"))
                 }
             }
         }

--- a/grails-app/services/grails/plugin/redissession/RedisPersistentService.groovy
+++ b/grails-app/services/grails/plugin/redissession/RedisPersistentService.groovy
@@ -340,6 +340,6 @@ class RedisPersistentService implements Persister {
             def storeFlash = grailsApplication.config.grails.plugin.redisdatabasesession.storeFlashScopeWithRedis
             return storeFlash instanceof Boolean ? storeFlash : false
         }
-        return true
+        return false
     }
 }

--- a/test/integration/grails/plugin/redissession/RedisPersistanceServiceSpec.groovy
+++ b/test/integration/grails/plugin/redissession/RedisPersistanceServiceSpec.groovy
@@ -88,5 +88,21 @@ class RedisPersistanceServiceSpec extends IntegrationSpec {
         keys.size() == 1
         keys.contains(key)
     }
+
+    void "test removeAttribute"() {
+        given:
+        applicationContext.redisPersistentService.create(SESSION_ID)
+        String key = 'key'
+        String value = 'value'
+
+        when:
+        applicationContext.redisPersistentService.setAttribute(SESSION_ID, key, value)
+        String storedValue = applicationContext.redisPersistentService.getAttribute(SESSION_ID, key)
+        applicationContext.redisPersistentService.removeAttribute(SESSION_ID, key)
+
+        then:
+        storedValue == value
+        applicationContext.redisPersistentService.getAttribute(SESSION_ID, key) == null
+    }
 }
 

--- a/test/integration/grails/plugin/redissession/RedisPersistanceServiceSpec.groovy
+++ b/test/integration/grails/plugin/redissession/RedisPersistanceServiceSpec.groovy
@@ -1,15 +1,27 @@
 package grails.plugin.redissession
 
+import grails.plugin.redissession.redis.TestRedisServiceFactory
 import grails.test.spock.IntegrationSpec
 
+/**
+ * RedisPersistanceService tests
+ *
+ * @author Daniel Muehlbachler
+ */
 class RedisPersistanceServiceSpec extends IntegrationSpec {
 
     private String SESSION_ID = "sessionId"
 
+    def redisService
+
     def setup() {
+        redisService = TestRedisServiceFactory.getInstance()
+        applicationContext.redisPersistentService.redisService = redisService
     }
 
     def cleanup() {
+        redisService.flushDB()
+        applicationContext.grailsApplication.config.grails.plugin.redisdatabasesession.sessionTimeout = null
     }
 
     void "test create default session"() {

--- a/test/integration/grails/plugin/redissession/RedisPersistanceServiceSpec.groovy
+++ b/test/integration/grails/plugin/redissession/RedisPersistanceServiceSpec.groovy
@@ -1,0 +1,80 @@
+package grails.plugin.redissession
+
+import grails.test.spock.IntegrationSpec
+
+class RedisPersistanceServiceSpec extends IntegrationSpec {
+
+    private String SESSION_ID = "sessionId"
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test create default session"() {
+        given:
+        String sessionId = "default:$SESSION_ID"
+
+        when:
+        applicationContext.redisPersistentService.create(sessionId)
+
+        then:
+        applicationContext.redisPersistentService.getMaxInactiveInterval(sessionId) == RedisPersistentService.DEFAULT_MAX_INACTIVE_INTERVAL
+    }
+
+    void "test create session with config sessionTimeout"() {
+        given:
+        String sessionId = "configTimeout:$SESSION_ID"
+        int sessionTimeout = 60
+        applicationContext.grailsApplication.config.grails.plugin.redisdatabasesession.sessionTimeout = sessionTimeout
+
+        when:
+        applicationContext.redisPersistentService.create(sessionId)
+
+        then:
+        applicationContext.redisPersistentService.getMaxInactiveInterval(sessionId) == sessionTimeout
+    }
+
+    void "test set inactive interval session"() {
+        given:
+        String sessionId = "setTimeout:$SESSION_ID"
+        int sessionTimeout = 45
+        applicationContext.redisPersistentService.create(sessionId)
+
+        when:
+        applicationContext.redisPersistentService.setMaxInactiveInterval(sessionId, sessionTimeout)
+
+        then:
+        applicationContext.redisPersistentService.getMaxInactiveInterval(sessionId) == sessionTimeout
+    }
+
+    void "test setAttribute and getAttribute"() {
+        given:
+        applicationContext.redisPersistentService.create(SESSION_ID)
+        String key = 'key'
+        String value = 'value'
+
+        when:
+        applicationContext.redisPersistentService.setAttribute(SESSION_ID, key, value)
+
+        then:
+        applicationContext.redisPersistentService.getAttribute(SESSION_ID, key) == value
+    }
+
+    void "test getAttributeNames"() {
+        given:
+        applicationContext.redisPersistentService.create(SESSION_ID)
+        String key = 'key'
+        String value = 'value'
+
+        when:
+        applicationContext.redisPersistentService.setAttribute(SESSION_ID, key, value)
+        List<String> keys = applicationContext.redisPersistentService.getAttributeNames(SESSION_ID)
+
+        then:
+        keys.size() == 1
+        keys.contains(key)
+    }
+}
+

--- a/test/integration/grails/plugin/redissession/redis/TestRedis.groovy
+++ b/test/integration/grails/plugin/redissession/redis/TestRedis.groovy
@@ -1,0 +1,121 @@
+package grails.plugin.redissession.redis
+
+import redis.clients.jedis.Jedis
+
+/**
+ * Redis Testing Instance which ONLY overwrites NEEDED methods!
+ *
+ * @author Daniel Muehlbachler
+ */
+class TestRedis extends Jedis {
+    Map<Object, Map> contents = [:]
+
+    public TestRedis(String host) {
+        super(host)
+    }
+
+    @Override
+    String flushDB() {
+        return contents.clear()
+    }
+
+    @Override
+    String hmset(String key, Map<String, String> hash) {
+        return contents.put(key, hash)
+    }
+
+    @Override
+    Long zadd(String key, double score, String member) {
+        Map members = contents.get(key)
+        if (!members) {
+            members = [:]
+            contents.put(key, members)
+        }
+        members.put(member, score)
+        return 1
+    }
+
+    @Override
+    Double zscore(String key, String member) {
+        return contents.get(key)?.get(member)
+    }
+
+    @Override
+    Map<String, String> hgetAll(String key) {
+        return contents.get(key)
+    }
+
+    @Override
+    byte[] hget(byte[] key, byte[] field) {
+        return contents.get(key.toList())?.get(field.toList())
+    }
+
+    @Override
+    Long hset(String key, String field, String value) {
+        return setFieldValue(key, field, value)
+    }
+
+    @Override
+    Long hset(byte[] key, byte[] field, byte[] value) {
+        return setFieldValue(key.toList(), field.toList(), value)
+    }
+
+    private Long setFieldValue(def key, def field, def value) {
+        Map fields = contents.get(key)
+        if (!fields) {
+            fields = [:]
+            contents.put(key, fields)
+        }
+        fields.put(field, value)
+        return 1
+    }
+
+    @Override
+    Long hdel(byte[] key, byte[] ... fields) {
+        Map contentFields = contents.get(key.toList())
+        if (contentFields) {
+            fields.each {
+                contentFields.remove(it.toList())
+            }
+        }
+        return 1
+    }
+
+    @Override
+    Set<byte[]> hkeys(byte[] key) {
+        return contents.get(key.toList())?.keySet().collect { it as byte[] }
+    }
+
+    @Override
+    Boolean exists(String key) {
+        return contents.containsKey(key)
+    }
+
+    @Override
+    Boolean exists(byte[] key) {
+        return contents.containsKey(key.toList())
+    }
+
+    @Override
+    Long del(String key) {
+        contents.remove(key)
+        return 1
+    }
+
+    @Override
+    Long del(byte[] key) {
+        contents.remove(key.toList())
+        return 1
+    }
+
+    @Override
+    Long zrem(String key, String... members) {
+        Map contentMembers = contents.get(key)
+        if (contentMembers) {
+            members.each {
+                contentMembers.remove(it)
+            }
+        }
+        return 1
+    }
+}

--- a/test/integration/grails/plugin/redissession/redis/TestRedisService.groovy
+++ b/test/integration/grails/plugin/redissession/redis/TestRedisService.groovy
@@ -1,0 +1,22 @@
+package grails.plugin.redissession.redis
+
+/**
+ * Redis Testing Service which creates a service using {@link TestRedis} for usage in tests.
+ *
+ * @author Daniel Muehlbachler
+ */
+class TestRedisService {
+    def redis
+
+    TestRedisService(TestRedis redis) {
+        this.redis = redis
+    }
+
+    def flushDB() {
+        redis.flushDB()
+    }
+
+    def withRedis(Closure closure) {
+        return closure(redis)
+    }
+}

--- a/test/integration/grails/plugin/redissession/redis/TestRedisServiceFactory.groovy
+++ b/test/integration/grails/plugin/redissession/redis/TestRedisServiceFactory.groovy
@@ -1,0 +1,15 @@
+package grails.plugin.redissession.redis
+
+/**
+ * Redis Testing Service Factory which created a {@link TestRedisService} for usage in tests!
+ *
+ * @author Daniel Muehlbachler
+ */
+class TestRedisServiceFactory {
+
+    public static TestRedisService getInstance() {
+        return new TestRedisService(new TestRedis("localhost"))
+    }
+
+    private TestRedisServiceFactory() {}
+}


### PR DESCRIPTION
please merge asap if everything is fine since we depend on this change :)


fixed:

- cannot cast list to int if no sessionTimeout is set
- when checking for session attributes, serialize the session key before calling redis.exist(...) since they are stored before using serialize(...)


added:

  - testing instance for redis server
  - adding tests for addAttribute and getAttributeNames
  - adding tests for creating a session


other changes:

  - bump version