### PR TITLE
Fix not working flash scope & injections

### DIFF
--- a/RedisDatabaseSessionGrailsPlugin.groovy
+++ b/RedisDatabaseSessionGrailsPlugin.groovy
@@ -3,7 +3,7 @@ import org.codehaus.groovy.grails.web.servlet.mvc.SynchronizerTokensHolder
 import javax.servlet.http.HttpSession
 
 class RedisDatabaseSessionGrailsPlugin {
-    def version = "1.2.3"
+    def version = "1.2.4"
     def grailsVersion = "2.0 > *"
     def loadAfter = ["database-session", "redis"]
     def dependsOn = ["database-session":"1.2.1 > *", "redis":"1.5.2 > *"]

--- a/RedisDatabaseSessionGrailsPlugin.groovy
+++ b/RedisDatabaseSessionGrailsPlugin.groovy
@@ -24,8 +24,10 @@ Stores HTTP sessions in a Redis data store.
 
 
     def doWithSpring = {
-        springConfig.addAlias 'gormPersisterService', 'redisPersistentService'
-        springConfig.addAlias 'databaseCleanupService', 'redisSessionCleanupService'
+        if (pluginEnabled(application.config)) {
+            springConfig.addAlias 'gormPersisterService', 'redisPersistentService'
+            springConfig.addAlias 'databaseCleanupService', 'redisSessionCleanupService'
+        }
     }
 
     def doWithApplicationContext = { applicationContext ->

--- a/grails-app/services/grails/plugin/redissession/RedisPersistentService.groovy
+++ b/grails-app/services/grails/plugin/redissession/RedisPersistentService.groovy
@@ -58,7 +58,9 @@ class RedisPersistentService implements Persister {
         if (GrailsApplicationAttributes.FLASH_SCOPE == key && !storeFlashScopeWithRedis()) {
             // special case; use request scope since a new deserialized instance is created each time it's retrieved from the session
             def fs = SessionProxyFilter.request.getAttribute(GrailsApplicationAttributes.FLASH_SCOPE)
-            return fs
+            if (fs != null) {
+                return fs
+            }
         }
 
         def attribute = null


### PR DESCRIPTION
Fixed:
 - Injections of gormPersisterService and databaseCleanupService should only happen if the plugin is really enabled.
 - Flash scope wasn't working when read from Redis