### PR TITLE
Fixed MissingMethodException on Jedis.hdel() in removeAttribute method

### DIFF
--- a/grails-app/services/grails/plugin/redissession/RedisPersistentService.groovy
+++ b/grails-app/services/grails/plugin/redissession/RedisPersistentService.groovy
@@ -136,7 +136,8 @@ class RedisPersistentService implements Persister {
             redisService.withRedis { Jedis redis ->
                 if (redis.exists(serialize("${SESSION_ATTRIBUTES_PREFIX}${sessionId}"))) {
                     // redis.hdel(byte[] key, byte[]... fields) cannot be called with just one field!
-                    byte[] serialzedKey = serialize(key)
+					//Note: output of serialize json can be String or byte[] based on value of useJson()
+                    def serialzedKey = serialize(key)
                     redis.hdel(serialize("${SESSION_ATTRIBUTES_PREFIX}${sessionId}"), serialzedKey, serialzedKey)
                 }
             }


### PR DESCRIPTION
**Error:** When using JSON serialization,  following exception is thrown:

``ERROR grails.app.services.grails.plugin.redissession.RedisPersistentService  - No signature of method: redis.clients.jedis.Jedis.hdel() is applicable for argument types: (java.lang.String, [B, [B) values: [{"type":"java.lang.String","value":"session_attributes:7fe791d6-5b11-4cba-b11e-7236b3c1eb3b"}, ...]
Possible solutions: hdel([B, [[B), hdel(java.lang.String, [Ljava.lang.String;), del([B), hget([B, [B), hset([B, [B, [B), del(java.lang.String)
groovy.lang.MissingMethodException: No signature of method: redis.clients.jedis.Jedis.hdel() is applicable for argument types: (java.lang.String, [B, [B) values: [{"type":"java.lang.String","value":"session_attributes:7fe791d6-5b11-4cba-b11e-7236b3c1eb3b"}, ...]
Possible solutions: hdel([B, [[B), hdel(java.lang.String, [Ljava.lang.String;), del([B), hget([B, [B), hset([B, [B, [B), del(java.lang.String)
    at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:55)
    at org.codehaus.groovy.runtime.callsite.PojoMetaClassSite.call(PojoMetaClassSite.java:46)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:124)
    at grails.plugin.redissession.RedisPersistentService$_removeAttribute_closure4.doCall(RedisPersistentService.groovy:140)`

**Root Cause**: When useJson = true then output of serialize(key) is String and not byte[]. 

**Fix**: Modified the type to def. This should allow the code to work in both JSON and default mode (byte[])
